### PR TITLE
font-familyにYuGothic Mediumを追加

### DIFF
--- a/src/styles/_global.scss
+++ b/src/styles/_global.scss
@@ -1,7 +1,7 @@
 html {
-  font-family: YakuHanJPs_Narrow, Roboto, 游ゴシック, 'Yu Gothic', YuGothic,
-    'Hiragino Kaku Gothic ProN', 'Hiragino Kaku Gothic Pro', メイリオ, Meiryo,
-    sans-serif !important;
+  font-family: YakuHanJPs_Narrow, Roboto, 游ゴシック, YuGothic,
+    'Yu Gothic Medium', 'Hiragino Kaku Gothic ProN', 'Hiragino Kaku Gothic Pro',
+    メイリオ, Meiryo, sans-serif !important;
 }
 
 a {


### PR DESCRIPTION
TODO: Windowsでの表示を検証する
https://kitahina.co/2019/03/yugothic-font-family-2019/