### PR TITLE
企業ロゴの画像に高さの上限を設定する

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "plume-ui",
   "description": "plume ui framework",
-  "version": "0.0.56",
+  "version": "0.0.57",
   "author": "plume-ui team",
   "main": "dist/index.js",
   "style": "dist/index.css",

--- a/src/components/CompanyLogo/_CompanyLogo.scss
+++ b/src/components/CompanyLogo/_CompanyLogo.scss
@@ -40,4 +40,6 @@
 .pl-company-logo-image {
   width: 100%;
   height: auto;
+  max-height: 100%;
+  object-fit: contain;
 }


### PR DESCRIPTION
横幅より高さの方がある、以下のような企業があるため（anriの場合は110x120の画像が返ってきている）
https://initial.inc/investors/V07379

`object-fix:contain`を指定すると見た目的に美しくないが、画像を引き伸ばして表示する訳にも行かないのでこうしている:
<a href="https://gyazo.com/31976c6e7eba093d1bb15f523a447b28"><img src="https://i.gyazo.com/31976c6e7eba093d1bb15f523a447b28.png" alt="Image from Gyazo" width="544"/></a>

ちなみにepでは画像が小さく表示されてしまっている
http://entrepedia.jp/investors/V07379