### PR TITLE
node12を使う

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
     "core-js": "^3.3.4",
     "lodash": "^4.17.15"
   },
+  "engines": {
+    "node": "12.x"
+  },
   "devDependencies": {
     "@babel/core": "^7.6.4",
     "@babel/preset-env": "^7.6.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "plume-ui",
   "description": "plume ui framework",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "author": "plume-ui team",
   "main": "dist/index.js",
   "style": "dist/index.css",


### PR DESCRIPTION
AWSのnodeのEOLで、Nowへのデプロイが死んでいるため
https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html